### PR TITLE
Add moduleNameMapper to Jest config

### DIFF
--- a/core/jest.config.cjs
+++ b/core/jest.config.cjs
@@ -2,4 +2,7 @@
 module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
+    moduleNameMapper: {
+        '^(\\./.+|\\../.+).js$': '$1',
+    },
 };


### PR DESCRIPTION
This fixes the errors caused by .js imports