### PR TITLE
Fix validateSPLTokenTransfer by filtering accounts with isSigner flag from multiSigners

### DIFF
--- a/core/src/validateTransfer.ts
+++ b/core/src/validateTransfer.ts
@@ -147,12 +147,14 @@ async function validateSPLTokenTransfer(
             throw new ValidateTransferError('invalid transfer');
 
         // Check that the expected reference keys exactly match the extra keys provided to the instruction.
-        const extraKeys = decodedInstruction.keys.multiSigners;
-        const length = extraKeys.length;
+        // Filter out any keys with isSigner=true from multiSigners to exclude owner accounts
+        const referenceKeys = decodedInstruction.keys.multiSigners.filter((signer) => !signer.isSigner);
+        const length = referenceKeys.length;
         if (length !== references.length) throw new ValidateTransferError('invalid references');
 
         for (let i = 0; i < length; i++) {
-            if (!extraKeys[i].pubkey.equals(references[i])) throw new ValidateTransferError(`invalid reference ${i}`);
+            if (!referenceKeys[i].pubkey.equals(references[i]))
+                throw new ValidateTransferError(`invalid reference ${i}`);
         }
     }
 


### PR DESCRIPTION
Addresses issue #239 where validateSPLTokenTransfer was failing with 'invalid references' error for SPL token transfers.

In our testing with Phantom wallet, we observed that the owner account (with isSigner=true) was appearing in the multiSigners array alongside actual reference accounts. This caused reference validation to fail as it expected only reference accounts in multiSigners.

This fix filters out accounts with isSigner=true from multiSigners before validating against expected references, which resolves the validation issue while maintaining compatibility with existing code.